### PR TITLE
Add set_exit_trap_for option for graceful stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,19 +127,10 @@ require 'kodama'
 
 Kodama::Client.start(:host => '127.0.0.1', :username => 'user') do |c|
   c.binlog_position_file = 'position.log'
+  c.gracefully_stop_on = [:QUIT, :INT]
 
   c.on_query_event do |event|
     p event.query
-  end
-
-  Signal.trap(:QUIT) do
-    if c.safe_to_stop?
-      # stop immediately
-      exit(0)
-    else
-      # stop after processing current loop
-      c.stop_request
-    end
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -120,6 +120,30 @@ Kodama::Client.start(:host => '127.0.0.1', :username => 'user') do |c|
 end
 ```
 
+### Graceful stop
+
+```ruby
+require 'kodama'
+
+Kodama::Client.start(:host => '127.0.0.1', :username => 'user') do |c|
+  c.binlog_position_file = 'position.log'
+
+  c.on_query_event do |event|
+    p event.query
+  end
+
+  Signal.trap(:QUIT) do
+    if c.safe_to_stop?
+      # stop immediately
+      exit(0)
+    else
+      # stop after processing current loop
+      c.stop_request
+    end
+  end
+end
+```
+
 ## Configuration
 
 ### binlog_position_file

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Kodama::Client.start(:host => '127.0.0.1', :username => 'user') do |c|
   c.connection_retry_limit = 100 # times
   c.connection_retry_wait = 3 # second
 
+  # Exit gracefully when kodama receives specified signals
+  c.set_exit_trap_for :QUIT, :INT
+
   c.on_query_event do |event|
     p event.query
   end
@@ -120,21 +123,6 @@ Kodama::Client.start(:host => '127.0.0.1', :username => 'user') do |c|
 end
 ```
 
-### Graceful stop
-
-```ruby
-require 'kodama'
-
-Kodama::Client.start(:host => '127.0.0.1', :username => 'user') do |c|
-  # Exit gracefully when kodama receives specified signals
-  c.set_exit_trap_for :QUIT, :INT
-
-  c.on_query_event do |event|
-    p event.query
-  end
-end
-```
-
 ## Configuration
 
 ### binlog_position_file
@@ -150,6 +138,17 @@ It accepts ``:debug``, ``:info``, ``:warn``, ``:error``, ``:fatal``.
 ### connection_retry_limit, connection_retry_wait
 
 If for some reason the connection to MySQL is terminated, Kodama will attempt to reconnect ``connection_retry_limit`` times, while waiting ``connection_retry_wait`` seconds between attempts.
+
+### set_exit_trap_for
+
+Kodama traps specified signals and stop gracefully.
+It accpets multiple signals like following.
+
+```ruby
+Kodama::Client.start do |c|
+  c.set_exit_trap_for :INT, :QUIT
+end
+```
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ end
 require 'kodama'
 
 Kodama::Client.start(:host => '127.0.0.1', :username => 'user') do |c|
-  c.binlog_position_file = 'position.log'
-  c.gracefully_stop_on = [:QUIT, :INT]
+  # Exit gracefully when kodama receives specified signals
+  c.set_exit_trap_for :QUIT, :INT
 
   c.on_query_event do |event|
     p event.query

--- a/lib/kodama/client.rb
+++ b/lib/kodama/client.rb
@@ -66,6 +66,12 @@ module Kodama
       @logger.level = LOG_LEVEL[level]
     end
 
+    def gracefully_stop_on=(signals)
+      (signals.kind_of?(Array) ? signals : [signals]).each do |signal|
+        set_exit_trap_for(signal)
+      end
+    end
+
     def binlog_client(url)
       Binlog::Client.new(url)
     end
@@ -122,6 +128,16 @@ module Kodama
 
     def stop_requested?
       @stop_requested
+    end
+
+    def set_exit_trap_for(signal)
+      Signal.trap(signal) do
+        if safe_to_stop?
+          exit(0)
+        else
+          stop_request
+        end
+      end
     end
 
     def process_event(event)

--- a/lib/kodama/client.rb
+++ b/lib/kodama/client.rb
@@ -66,9 +66,15 @@ module Kodama
       @logger.level = LOG_LEVEL[level]
     end
 
-    def gracefully_stop_on=(signals)
-      Array(signals).each do |signal|
-        set_exit_trap_for(signal)
+    def set_exit_trap_for(*signals)
+      signals.each do |signal|
+        Signal.trap(signal) do
+          if safe_to_stop?
+            exit(0)
+          else
+            stop_request
+          end
+        end
       end
     end
 
@@ -128,16 +134,6 @@ module Kodama
 
     def stop_requested?
       @stop_requested
-    end
-
-    def set_exit_trap_for(signal)
-      Signal.trap(signal) do
-        if safe_to_stop?
-          exit(0)
-        else
-          stop_request
-        end
-      end
     end
 
     def process_event(event)

--- a/lib/kodama/client.rb
+++ b/lib/kodama/client.rb
@@ -67,7 +67,7 @@ module Kodama
     end
 
     def gracefully_stop_on=(signals)
-      (signals.kind_of?(Array) ? signals : [signals]).each do |signal|
+      Array(signals).each do |signal|
         set_exit_trap_for(signal)
       end
     end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -126,7 +126,7 @@ describe Kodama::Client do
       client.connection_retry_count.should == 2
     end
 
-    it 'should stop when it is received stop request' do
+    it 'should stop when it receives stop request' do
       stub_binlog_client([query_event, row_event])
       client.on_query_event do |event|
         self.stop_request

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -125,5 +125,14 @@ describe Kodama::Client do
       expect { client.start }.to raise_error(Binlog::Error)
       client.connection_retry_count.should == 2
     end
+
+    it 'should stop when it is received stop request' do
+      stub_binlog_client([query_event, row_event])
+      client.on_query_event do |event|
+        self.stop_request
+      end
+      expect {|block| client.on_row_event(&block) }.not_to yield_control
+      client.start
+    end
   end
 end


### PR DESCRIPTION
In general, when user send termination signal like `SIGQUIT` or `SIGINT`, Kodama stops immediately.
But this is likely to make invalid position log because signal interrupts Kodama's main event loop.

To avoid such situation, I add gracefully stop option - `set_exit_trap_for`.
Kodama stops after processing current event loop by setting signals to this option.
